### PR TITLE
Automatically precompile Gtk.jl for newer versions of Julia.

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -1,5 +1,5 @@
 # julia Gtk interface
-
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
 module Gtk
 
 const suffix = :Leaf


### PR DESCRIPTION
Tested on 64 bit Linux. Reduced load time from 5.8 s to 1.1 s on Core i7, 3.4 GHz.
